### PR TITLE
adds crypt key factory to server factories for private and public keys

### DIFF
--- a/src/AuthorizationServerFactory.php
+++ b/src/AuthorizationServerFactory.php
@@ -21,6 +21,7 @@ use Psr\Container\ContainerInterface;
 
 class AuthorizationServerFactory
 {
+    use CryptKeyTrait;
     use RepositoryTrait;
 
     public function __invoke(ContainerInterface $container) : AuthorizationServer
@@ -58,11 +59,14 @@ class AuthorizationServerFactory
                 'The auth_code_expire value is missing in config authentication'
             );
         }
+
+        $privateKey = $this->getCryptKey($config['private_key'], 'authentication.private_key');
+
         $authServer = new AuthorizationServer(
             $clientRepository,
             $accessTokenRepository,
             $scopeRepository,
-            $config['private_key'],
+            $privateKey,
             $config['encryption_key']
         );
 

--- a/src/CryptKeyTrait.php
+++ b/src/CryptKeyTrait.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-authentication-oauth2 for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-authentication-oauth2/blob/master/LICENSE.md
+ *     New BSD License
+ */
+
+namespace Zend\Expressive\Authentication\OAuth2;
+
+use League\OAuth2\Server\CryptKey;
+
+trait CryptKeyTrait
+{
+    protected function getCryptKey($keyConfig, string $configPath) : CryptKey
+    {
+        if (is_string($keyConfig)) {
+            return new CryptKey($keyConfig);
+        }
+
+        if (! isset($keyConfig['key_or_path'])) {
+            throw new Exception\InvalidConfigException(
+                sprintf('The key_or_path value is missing in config %s', $configPath)
+            );
+        }
+
+        $passPhrase = $keyConfig['pass_phrase'] ?? null;
+
+        if (isset($keyConfig['key_permissions_check'])) {
+            return new CryptKey($keyConfig['key_or_path'], $passPhrase, (bool) $keyConfig['key_permissions_check']);
+        }
+
+        return new CryptKey($keyConfig['key_or_path'], $passPhrase);
+    }
+}

--- a/src/ResourceServerFactory.php
+++ b/src/ResourceServerFactory.php
@@ -13,6 +13,7 @@ use Psr\Container\ContainerInterface;
 
 class ResourceServerFactory
 {
+    use CryptKeyTrait;
     use RepositoryTrait;
 
     public function __invoke(ContainerInterface $container) : ResourceServer
@@ -26,9 +27,11 @@ class ResourceServerFactory
             );
         }
 
+        $publicKey = $this->getCryptKey($config['public_key'], 'authentication.public_key');
+
         return new ResourceServer(
             $this->getAccessTokenRepository($container),
-            $config['public_key']
+            $publicKey
         );
     }
 }


### PR DESCRIPTION
This PR provides and implements a `CryptKeyTrait` for factories using private and public keys.

The league package provides options for crypt keys (pass_phrase and a key_permissions_check flag), which could not used from current server factories of this package.

A much cleaner approach would be to implement a CryptKeyFactory and call that factory from container, but i was not sure about your future plans for this packages configuration.