### PR TITLE
Updated composer.lock for PSR HTTP Server deps, fixed typos in FQCNs

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -918,16 +918,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.3",
+            "version": "1.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf"
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
-                "reference": "e4ed002c67da8eceb0eb8ddb8b3847bb53c5c2bf",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
                 "shasum": ""
             },
             "require": {
@@ -939,7 +939,7 @@
             },
             "require-dev": {
                 "phpspec/phpspec": "^2.5|^3.2",
-                "phpunit/phpunit": "^4.8.35 || ^5.7"
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5"
             },
             "type": "library",
             "extra": {
@@ -977,7 +977,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2017-11-24T13:59:53+00:00"
+            "time": "2018-02-19T10:16:54+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1377,12 +1377,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "3df94834c80037130b533703df4672785b6ea112"
+                "reference": "b5def2d9e0121c82083f552a90f7b499531a20fb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/3df94834c80037130b533703df4672785b6ea112",
-                "reference": "3df94834c80037130b533703df4672785b6ea112",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/b5def2d9e0121c82083f552a90f7b499531a20fb",
+                "reference": "b5def2d9e0121c82083f552a90f7b499531a20fb",
                 "shasum": ""
             },
             "conflict": {
@@ -1432,9 +1432,12 @@
                 "onelogin/php-saml": "<2.10.4",
                 "oro/crm": ">=1.7,<1.7.4",
                 "oro/platform": ">=1.7,<1.7.4",
+                "padraic/humbug_get_contents": "<1.1.2",
                 "phpmailer/phpmailer": ">=5,<5.2.24",
                 "phpunit/phpunit": ">=4.8.19,<4.8.28|>=5.0.10,<5.6.3",
                 "phpxmlrpc/extras": "<0.6.1",
+                "propel/propel": ">=2.0.0-alpha1,<=2.0.0-alpha7",
+                "propel/propel1": ">=1,<=1.7.1",
                 "pusher/pusher-php-server": "<2.2.1",
                 "sabre/dav": ">=1.6,<1.6.99|>=1.7,<1.7.11|>=1.8,<1.8.9",
                 "shopware/shopware": "<5.3.7",
@@ -1466,16 +1469,16 @@
                 "symfony/web-profiler-bundle": ">=2,<2.3.19|>=2.4,<2.4.9|>=2.5,<2.5.4",
                 "symfony/yaml": ">=2,<2.0.22|>=2.1,<2.1.7",
                 "thelia/backoffice-default-template": ">=2.1,<2.1.2",
-                "thelia/thelia": ">=2.1.0-beta1,<2.1.3|>=2.1,<2.1.2",
+                "thelia/thelia": ">=2.1,<2.1.2|>=2.1.0-beta1,<2.1.3",
                 "twig/twig": "<1.20",
                 "typo3/cms": ">=6.2,<6.2.30|>=7,<7.6.22|>=8,<8.7.5",
                 "typo3/flow": ">=1,<1.0.4|>=1.1,<1.1.1|>=2,<2.0.1|>=2.3,<2.3.16|>=3,<3.0.10|>=3.1,<3.1.7|>=3.2,<3.2.7|>=3.3,<3.3.5",
                 "typo3/neos": ">=1.1,<1.1.3|>=1.2,<1.2.13|>=2,<2.0.4",
                 "willdurand/js-translation-bundle": "<2.1.1",
                 "yiisoft/yii": ">=1.1.14,<1.1.15",
-                "yiisoft/yii2": "<2.0.5",
+                "yiisoft/yii2": "<2.0.14",
                 "yiisoft/yii2-bootstrap": "<2.0.4",
-                "yiisoft/yii2-dev": "<2.0.4",
+                "yiisoft/yii2-dev": "<2.0.14",
                 "yiisoft/yii2-gii": "<2.0.4",
                 "yiisoft/yii2-jui": "<2.0.4",
                 "zendframework/zend-cache": ">=2.4,<2.4.8|>=2.5,<2.5.3",
@@ -1515,7 +1518,7 @@
                 }
             ],
             "description": "Prevents installation of composer packages with known security vulnerabilities: no API, simply require it",
-            "time": "2018-02-04T22:09:50+00:00"
+            "time": "2018-02-20T15:56:25+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -12,9 +12,11 @@ namespace Zend\Expressive\Authentication\OAuth2;
 
 use League\OAuth2\Server\AuthorizationServer;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
+use League\OAuth2\Server\Repositories\AuthCodeRepositoryInterface;
 use League\OAuth2\Server\Repositories\ClientRepositoryInterface;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
+use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\ResourceServer;
 use Zend\Expressive\Authentication\OAuth2\Repository\Pdo;
 
@@ -40,12 +42,12 @@ class ConfigProvider
         return [
             'aliases' => [
                 // Choose a different adapter changing the alias value
-                AccessTokenRepositoryInterface::class => Pdo\AccessTokenRepository,
-                AuthCodeEntityInterface::class => Pdo\AuthCodeRepository,
-                ClientRepositoryInterface::class => Pdo\ClientRepository,
-                RefreshTokenRepositoryInterface::class => Pdo\RefreshTokenRepository,
-                ScopeRepositoryInterface::class => Pdo\ScopeRepository,
-                UserRepositoryInterface::class => Pdo\UserRepository
+                AccessTokenRepositoryInterface::class => Pdo\AccessTokenRepository::class,
+                AuthCodeRepositoryInterface::class => Pdo\AuthCodeRepository::class,
+                ClientRepositoryInterface::class => Pdo\ClientRepository::class,
+                RefreshTokenRepositoryInterface::class => Pdo\RefreshTokenRepository::class,
+                ScopeRepositoryInterface::class => Pdo\ScopeRepository::class,
+                UserRepositoryInterface::class => Pdo\UserRepository::class
             ],
             'factories' => [
                 OAuth2Middleware::class => OAuth2MiddlewareFactory::class,

--- a/test/Pdo/OAuth2PdoMiddlewareTest.php
+++ b/test/Pdo/OAuth2PdoMiddlewareTest.php
@@ -49,7 +49,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
         if (false === $pdo->exec(file_get_contents(self::DB_SCHEMA))) {
             throw new \Exception(sprintf(
                 "The test cannot be executed without the %s db",
-                $dbSchema
+                self::DB_SCHEMA
             ));
         }
         // Insert the test values
@@ -371,10 +371,10 @@ class OAuth2PdoMiddlewareTest extends TestCase
      * Build a ServerRequest object
      *
      * @param string $method
-     * @param sting $url
+     * @param string $url
      * @param array $params
      * @param array $headers
-     * @return Zend\Diactoros\ServerRequest
+     * @return \Zend\Diactoros\ServerRequest
      */
     protected function buildServerRequest($method, $url, $body, $params, $headers = [], $queryParams = [])
     {


### PR DESCRIPTION
- PSR HTTP server dependency in composer.lock was outdated
- Some typos in class names for aliases in ConfigProvider
- Minor typos in unit tests