### PR TITLE
Added revokable trait for entities

### DIFF
--- a/src/Entity/AccessTokenEntity.php
+++ b/src/Entity/AccessTokenEntity.php
@@ -17,5 +17,5 @@ use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
 
 class AccessTokenEntity implements AccessTokenEntityInterface
 {
-    use AccessTokenTrait, TokenEntityTrait, EntityTrait, RevokableTrait;
+    use AccessTokenTrait, TokenEntityTrait, EntityTrait, RevokableTrait, TimestampableTrait;
 }

--- a/src/Entity/AccessTokenEntity.php
+++ b/src/Entity/AccessTokenEntity.php
@@ -17,5 +17,5 @@ use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
 
 class AccessTokenEntity implements AccessTokenEntityInterface
 {
-    use AccessTokenTrait, TokenEntityTrait, EntityTrait;
+    use AccessTokenTrait, TokenEntityTrait, EntityTrait, RevokableTrait;
 }

--- a/src/Entity/AuthCodeEntity.php
+++ b/src/Entity/AuthCodeEntity.php
@@ -17,5 +17,5 @@ use League\OAuth2\Server\Entities\Traits\TokenEntityTrait;
 
 class AuthCodeEntity implements AuthCodeEntityInterface
 {
-    use AuthCodeTrait, EntityTrait, TokenEntityTrait;
+    use AuthCodeTrait, EntityTrait, TokenEntityTrait, RevokableTrait;
 }

--- a/src/Entity/ClientEntity.php
+++ b/src/Entity/ClientEntity.php
@@ -16,7 +16,7 @@ use League\OAuth2\Server\Entities\Traits\EntityTrait;
 
 class ClientEntity implements ClientEntityInterface
 {
-    use ClientTrait, EntityTrait;
+    use ClientTrait, EntityTrait, RevokableTrait;
 
     /**
      * Constructor

--- a/src/Entity/ClientEntity.php
+++ b/src/Entity/ClientEntity.php
@@ -48,49 +48,31 @@ class ClientEntity implements ClientEntityInterface
         $this->redirectUri = explode(',', $redirectUri);
     }
 
-    /**
-     * @return string
-     */
     public function getSecret(): string
     {
         return $this->secret;
     }
 
-    /**
-     * @param string $secret
-     */
     public function setSecret(string $secret): void
     {
         $this->secret = $secret;
     }
 
-    /**
-     * @return bool
-     */
     public function hasPersonalAccessClient(): bool
     {
         return $this->personalAccessClient;
     }
 
-    /**
-     * @param bool $personalAccessClient
-     */
     public function setPersonalAccessClient(bool $personalAccessClient): void
     {
         $this->personalAccessClient = $personalAccessClient;
     }
 
-    /**
-     * @return bool
-     */
     public function hasPasswordClient(): bool
     {
         return $this->passwordClient;
     }
 
-    /**
-     * @param bool $passwordClient
-     */
     public function setPasswordClient(bool $passwordClient): void
     {
         $this->passwordClient = $passwordClient;

--- a/src/Entity/ClientEntity.php
+++ b/src/Entity/ClientEntity.php
@@ -16,7 +16,7 @@ use League\OAuth2\Server\Entities\Traits\EntityTrait;
 
 class ClientEntity implements ClientEntityInterface
 {
-    use ClientTrait, EntityTrait, RevokableTrait;
+    use ClientTrait, EntityTrait, RevokableTrait, TimestampableTrait;
 
     /**
      * Constructor

--- a/src/Entity/ClientEntity.php
+++ b/src/Entity/ClientEntity.php
@@ -19,6 +19,21 @@ class ClientEntity implements ClientEntityInterface
     use ClientTrait, EntityTrait, RevokableTrait, TimestampableTrait;
 
     /**
+     * @var string
+     */
+    protected $secret;
+
+    /**
+     * @var bool
+     */
+    protected $personalAccessClient;
+
+    /**
+     * @var bool
+     */
+    protected $passwordClient;
+
+    /**
      * Constructor
      *
      * @param  string  $identifier
@@ -31,5 +46,53 @@ class ClientEntity implements ClientEntityInterface
         $this->setIdentifier($identifier);
         $this->name = $name;
         $this->redirectUri = explode(',', $redirectUri);
+    }
+
+    /**
+     * @return string
+     */
+    public function getSecret(): string
+    {
+        return $this->secret;
+    }
+
+    /**
+     * @param string $secret
+     */
+    public function setSecret(string $secret): void
+    {
+        $this->secret = $secret;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPersonalAccessClient(): bool
+    {
+        return $this->personalAccessClient;
+    }
+
+    /**
+     * @param bool $personalAccessClient
+     */
+    public function setPersonalAccessClient(bool $personalAccessClient): void
+    {
+        $this->personalAccessClient = $personalAccessClient;
+    }
+
+    /**
+     * @return bool
+     */
+    public function hasPasswordClient(): bool
+    {
+        return $this->passwordClient;
+    }
+
+    /**
+     * @param bool $passwordClient
+     */
+    public function setPasswordClient(bool $passwordClient): void
+    {
+        $this->passwordClient = $passwordClient;
     }
 }

--- a/src/Entity/RefreshTokenEntity.php
+++ b/src/Entity/RefreshTokenEntity.php
@@ -16,5 +16,5 @@ use League\OAuth2\Server\Entities\Traits\RefreshTokenTrait;
 
 class RefreshTokenEntity implements RefreshTokenEntityInterface
 {
-    use EntityTrait, RefreshTokenTrait;
+    use EntityTrait, RefreshTokenTrait, RevokableTrait;
 }

--- a/src/Entity/RevokableTrait.php
+++ b/src/Entity/RevokableTrait.php
@@ -1,10 +1,12 @@
 <?php
 /**
- * Created by PhpStorm.
- * User: julien
- * Date: 21/02/2018
- * Time: 10:14
+ * @see       https://github.com/zendframework/zend-expressive-authentication-oauth2 for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-authentication-oauth2/blob/master/LICENSE.md
+ *     New BSD License
  */
+
+declare(strict_types=1);
 
 namespace Zend\Expressive\Authentication\OAuth2\Entity;
 

--- a/src/Entity/RevokableTrait.php
+++ b/src/Entity/RevokableTrait.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: julien
+ * Date: 21/02/2018
+ * Time: 10:14
+ */
+
+namespace Zend\Expressive\Authentication\OAuth2\Entity;
+
+trait RevokableTrait
+{
+    /**
+     * @var bool
+     */
+    protected $revoked;
+
+    /**
+     * @return bool
+     */
+    public function isRevoked(): bool
+    {
+        return $this->revoked;
+    }
+
+    /**
+     * @param bool $revoked
+     */
+    public function setRevoked(bool $revoked): void
+    {
+        $this->revoked = $revoked;
+    }
+}

--- a/src/Entity/TimestampableTrait.php
+++ b/src/Entity/TimestampableTrait.php
@@ -55,4 +55,17 @@ trait TimestampableTrait
     {
         $this->updatedAt = $updatedAt;
     }
+
+    /**
+     *
+     */
+    public function timestampOnCreate(): void
+    {
+        if (! $this->createdAt) {
+            $this->createdAt = new DateTime();
+            if (method_exists($this, 'getTimezone')) {
+                $this->createdAt->setTimezone(new \DateTimeZone(($this->getTimezone()->getValue())));
+            }
+        }
+    }
 }

--- a/src/Entity/TimestampableTrait.php
+++ b/src/Entity/TimestampableTrait.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-expressive-authentication-oauth2 for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-expressive-authentication-oauth2/blob/master/LICENSE.md
+ *     New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Zend\Expressive\Authentication\OAuth2\Entity;
+
+use DateTime;
+
+trait TimestampableTrait
+{
+    /**
+     * @var DateTime
+     */
+    protected $createdAt;
+
+    /**
+     * @var DateTime
+     */
+    protected $updatedAt;
+
+    /**
+     * @return DateTime
+     */
+    public function getCreatedAt(): DateTime
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @param DateTime $createdAt
+     */
+    public function setCreatedAt(DateTime $createdAt): void
+    {
+        $this->createdAt = $createdAt;
+    }
+
+    /**
+     * @return DateTime
+     */
+    public function getUpdatedAt(): DateTime
+    {
+        return $this->updatedAt;
+    }
+
+    /**
+     * @param DateTime $updatedAt
+     */
+    public function setUpdatedAt(DateTime $updatedAt): void
+    {
+        $this->updatedAt = $updatedAt;
+    }
+}

--- a/src/Entity/TimestampableTrait.php
+++ b/src/Entity/TimestampableTrait.php
@@ -11,60 +11,44 @@ declare(strict_types=1);
 namespace Zend\Expressive\Authentication\OAuth2\Entity;
 
 use DateTime;
+use DateTimeZone;
 
 trait TimestampableTrait
 {
-    /**
-     * @var DateTime
-     */
     protected $createdAt;
 
-    /**
-     * @var DateTime
-     */
     protected $updatedAt;
 
-    /**
-     * @return DateTime
-     */
-    public function getCreatedAt(): DateTime
+    public function getCreatedAt() : DateTime
     {
         return $this->createdAt;
     }
 
-    /**
-     * @param DateTime $createdAt
-     */
-    public function setCreatedAt(DateTime $createdAt): void
+    public function setCreatedAt(DateTime $createdAt) : void
     {
         $this->createdAt = $createdAt;
     }
 
-    /**
-     * @return DateTime
-     */
-    public function getUpdatedAt(): DateTime
+    public function getUpdatedAt() : DateTime
     {
         return $this->updatedAt;
     }
 
-    /**
-     * @param DateTime $updatedAt
-     */
-    public function setUpdatedAt(DateTime $updatedAt): void
+    public function setUpdatedAt(DateTime $updatedAt) : void
     {
         $this->updatedAt = $updatedAt;
     }
 
     /**
-     *
+     * Set createdAt on current date/time if not set, using
+     * timezone if defined
      */
-    public function timestampOnCreate(): void
+    public function timestampOnCreate() : void
     {
         if (! $this->createdAt) {
             $this->createdAt = new DateTime();
             if (method_exists($this, 'getTimezone')) {
-                $this->createdAt->setTimezone(new \DateTimeZone(($this->getTimezone()->getValue())));
+                $this->createdAt->setTimezone(new DateTimeZone($this->getTimezone()->getValue()));
             }
         }
     }

--- a/src/Entity/TimestampableTrait.php
+++ b/src/Entity/TimestampableTrait.php
@@ -15,8 +15,14 @@ use DateTimeZone;
 
 trait TimestampableTrait
 {
+    /**
+     * @var DateTime
+     */
     protected $createdAt;
 
+    /**
+     * @var DateTime
+     */
     protected $updatedAt;
 
     public function getCreatedAt() : DateTime

--- a/test/OAuth2AdapterFactoryTest.php
+++ b/test/OAuth2AdapterFactoryTest.php
@@ -34,7 +34,7 @@ class OAuth2AdapterFactoryTest extends TestCase
     }
 
     /**
-     * @expectedException Zend\Expressive\Authentication\OAuth2\Exception\InvalidConfigException
+     * @expectedException \Zend\Expressive\Authentication\OAuth2\Exception\InvalidConfigException
      */
     public function testInvokeWithEmptyContainer()
     {


### PR DESCRIPTION
`revoked` being a field of all tables, it should be available as a property for bound entities.
This PR adds a trait with `getter` and `setter` in every entity, allowing objects to reflect their DB entry.