### PR TITLE
Removes Zend\Expressive\Authentication\ResponsePrototypeTrait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
+## 1.0.0alpha3 - 2018-02-27
+
+### Added
+
+- Nothing.
+
+### Changed
+
+- [#17](https://github.com/zendframework/zend-expressive-authentication-oauth2/pull/17)
+  changes the constructor of each of the `Zend\Expressive\Authentication\OAuth2\OAuth2Adapter`
+  and `Zend\Expressive\Authentication\OAuth2\OAuth2Middleware` classes to accept
+  a callable `$responseFactory` instead of a `Psr\Http\Message\ResponseInterface` 
+  response prototype. The `$responseFactory` should produce a
+  `ResponseInterface` implementation when invoked.
+
+- [#17](https://github.com/zendframework/zend-expressive-authentication-oauth2/pull/17)
+  updates the `OAuth2AdapterFactory` and `OAuth2MiddlewareFactory` classes to no
+  longer use `Zend\Expressive\Authentication\ResponsePrototypeTrait`, and
+  instead always depend on the `Psr\Http\Message\ResponseInterface` service to
+  correctly return a PHP callable capable of producing a `ResponseInterface`
+  instance.
+
+### Deprecated
+
+- Nothing.
+
+### Removed
+
+- Nothing.
+
+### Fixed
+
+- Nothing.
+
 ## 1.0.0alpha2 - 2018-02-26
 
 ### Added

--- a/src/OAuth2Adapter.php
+++ b/src/OAuth2Adapter.php
@@ -28,9 +28,9 @@ class OAuth2Adapter implements AuthenticationInterface
     protected $resourceServer;
 
     /**
-     * @var ResponseInterface
+     * @var callable
      */
-    protected $responsePrototype;
+    protected $responseFactory;
 
     /**
      * Constructor
@@ -38,10 +38,12 @@ class OAuth2Adapter implements AuthenticationInterface
      * @param ResourceServer $resourceServer
      * @param ResponseInterface $responsePrototype
      */
-    public function __construct(ResourceServer $resourceServer, ResponseInterface $responsePrototype)
+    public function __construct(ResourceServer $resourceServer, callable $responseFactory)
     {
         $this->resourceServer = $resourceServer;
-        $this->responsePrototype = $responsePrototype;
+        $this->responseFactory = function () use ($responseFactory) : ResponseInterface {
+            return $responseFactory();
+        };
     }
 
     /**
@@ -66,7 +68,7 @@ class OAuth2Adapter implements AuthenticationInterface
      */
     public function unauthorizedResponse(ServerRequestInterface $request) : ResponseInterface
     {
-        return $this->responsePrototype
+        return ($this->responseFactory)()
             ->withHeader(
                 'WWW-Authenticate',
                 'Bearer token-example'

--- a/src/OAuth2Adapter.php
+++ b/src/OAuth2Adapter.php
@@ -32,12 +32,6 @@ class OAuth2Adapter implements AuthenticationInterface
      */
     protected $responseFactory;
 
-    /**
-     * Constructor
-     *
-     * @param ResourceServer $resourceServer
-     * @param ResponseInterface $responsePrototype
-     */
     public function __construct(ResourceServer $resourceServer, callable $responseFactory)
     {
         $this->resourceServer = $resourceServer;

--- a/src/OAuth2AdapterFactory.php
+++ b/src/OAuth2AdapterFactory.php
@@ -12,13 +12,11 @@ namespace Zend\Expressive\Authentication\OAuth2;
 
 use League\OAuth2\Server\ResourceServer;
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
 use Zend\Expressive\Authentication\OAuth2\Exception;
-use Zend\Expressive\Authentication\ResponsePrototypeTrait;
 
 class OAuth2AdapterFactory
 {
-    use ResponsePrototypeTrait;
-
     public function __invoke(ContainerInterface $container) : OAuth2Adapter
     {
         $resourceServer = $container->has(ResourceServer::class)
@@ -33,7 +31,7 @@ class OAuth2AdapterFactory
 
         return new OAuth2Adapter(
             $resourceServer,
-            $this->getResponsePrototype($container)
+            $container->get(ResponseInterface::class)
         );
     }
 }

--- a/src/OAuth2Middleware.php
+++ b/src/OAuth2Middleware.php
@@ -30,12 +30,6 @@ class OAuth2Middleware implements MiddlewareInterface
      */
     protected $responseFactory;
 
-    /**
-     * Constructor
-     *
-     * @param AuthorizationServer $server
-     * @param ResponseInterface $responsePrototype
-     */
     public function __construct(AuthorizationServer $server, callable $responseFactory)
     {
         $this->server = $server;

--- a/src/OAuth2MiddlewareFactory.php
+++ b/src/OAuth2MiddlewareFactory.php
@@ -12,12 +12,10 @@ namespace Zend\Expressive\Authentication\OAuth2;
 
 use League\OAuth2\Server\AuthorizationServer;
 use Psr\Container\ContainerInterface;
-use Zend\Expressive\Authentication\ResponsePrototypeTrait;
+use Psr\Http\Message\ResponseInterface;
 
 class OAuth2MiddlewareFactory
 {
-    use ResponsePrototypeTrait;
-
     public function __invoke(ContainerInterface $container) : OAuth2Middleware
     {
         $authServer = $container->has(AuthorizationServer::class)
@@ -33,7 +31,7 @@ class OAuth2MiddlewareFactory
 
         return new OAuth2Middleware(
             $authServer,
-            $this->getResponsePrototype($container)
+            $container->get(ResponseInterface::class)
         );
     }
 }

--- a/test/OAuth2AdapterFactoryTest.php
+++ b/test/OAuth2AdapterFactoryTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Authentication\OAuth2;
 
-use function foo\func;
 use League\OAuth2\Server\ResourceServer;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;

--- a/test/OAuth2AdapterFactoryTest.php
+++ b/test/OAuth2AdapterFactoryTest.php
@@ -12,6 +12,7 @@ namespace ZendTest\Expressive\Authentication\OAuth2;
 
 use League\OAuth2\Server\ResourceServer;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 use Zend\Expressive\Authentication\AuthenticationInterface;
@@ -20,11 +21,26 @@ use Zend\Expressive\Authentication\OAuth2\OAuth2AdapterFactory;
 
 class OAuth2AdapterFactoryTest extends TestCase
 {
+    /** @var ContainerInterface|ObjectProphecy */
+    private $container;
+
+    /** @var ResourceServer|ObjectProphecy */
+    private $resourceServer;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $response;
+
+    /** @var callable */
+    private $responseFactory;
+
     public function setUp()
     {
-        $this->container      = $this->prophesize(ContainerInterface::class);
-        $this->resourceServer = $this->prophesize(ResourceServer::class);
-        $this->response       = $this->prophesize(ResponseInterface::class);
+        $this->container       = $this->prophesize(ContainerInterface::class);
+        $this->resourceServer  = $this->prophesize(ResourceServer::class);
+        $this->response        = $this->prophesize(ResponseInterface::class);
+        $this->responseFactory = function () {
+            return $this->response->reveal();
+        };
     }
 
     public function testConstructor()
@@ -77,9 +93,7 @@ class OAuth2AdapterFactoryTest extends TestCase
             ->willReturn(true);
         $this->container
             ->get(ResponseInterface::class)
-            ->willReturn(function () {
-                return $this->response->reveal();
-            });
+            ->willReturn($this->responseFactory);
 
         $factory = new OAuth2AdapterFactory();
         $adapter = $factory($this->container->reveal());

--- a/test/OAuth2AdapterFactoryTest.php
+++ b/test/OAuth2AdapterFactoryTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 
 namespace ZendTest\Expressive\Authentication\OAuth2;
 
+use function foo\func;
 use League\OAuth2\Server\ResourceServer;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
@@ -52,8 +53,8 @@ class OAuth2AdapterFactoryTest extends TestCase
             ->willReturn($this->resourceServer->reveal());
 
         $this->container
-            ->has(ResponseInterface::class)
-            ->willReturn(false);
+            ->get(ResponseInterface::class)
+            ->willReturn(function () {});
 
         $factory = new OAuth2AdapterFactory();
         $adapter = $factory($this->container->reveal());

--- a/test/OAuth2AdapterFactoryTest.php
+++ b/test/OAuth2AdapterFactoryTest.php
@@ -54,7 +54,8 @@ class OAuth2AdapterFactoryTest extends TestCase
 
         $this->container
             ->get(ResponseInterface::class)
-            ->willReturn(function () {});
+            ->willReturn(function () {
+            });
 
         $factory = new OAuth2AdapterFactory();
         $adapter = $factory($this->container->reveal());

--- a/test/OAuth2AdapterTest.php
+++ b/test/OAuth2AdapterTest.php
@@ -30,9 +30,13 @@ class OAuth2AdapterTest extends TestCase
 
     public function testConstructor()
     {
+        $factory = function () {
+            return;
+        };
+
         $adapter = new OAuth2Adapter(
             $this->resourceServer->reveal(),
-            $this->response->reveal()
+            $factory
         );
         $this->assertInstanceOf(OAuth2Adapter::class, $adapter);
         $this->assertInstanceOf(AuthenticationInterface::class, $adapter);
@@ -50,7 +54,9 @@ class OAuth2AdapterTest extends TestCase
 
         $adapter = new OAuth2Adapter(
             $this->resourceServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
 
         $this->assertNull($adapter->authenticate($request->reveal()));
@@ -67,7 +73,9 @@ class OAuth2AdapterTest extends TestCase
 
         $adapter = new OAuth2Adapter(
             $this->resourceServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
 
         $this->assertNull($adapter->authenticate($request->reveal()));
@@ -84,7 +92,9 @@ class OAuth2AdapterTest extends TestCase
 
         $adapter = new OAuth2Adapter(
             $this->resourceServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
 
         $user = $adapter->authenticate($request->reveal());
@@ -107,7 +117,9 @@ class OAuth2AdapterTest extends TestCase
 
         $adapter = new OAuth2Adapter(
             $this->resourceServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
 
         $this->assertSame(

--- a/test/OAuth2AdapterTest.php
+++ b/test/OAuth2AdapterTest.php
@@ -22,21 +22,29 @@ use Zend\Expressive\Authentication\UserInterface;
 
 class OAuth2AdapterTest extends TestCase
 {
+    /** @var ResourceServer|ObjectProphecy */
+    private $resourceServer;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $response;
+
+    /** @var callable */
+    private $responseFactory;
+
     public function setUp()
     {
-        $this->resourceServer = $this->prophesize(ResourceServer::class);
-        $this->response       = $this->prophesize(ResponseInterface::class);
+        $this->resourceServer  = $this->prophesize(ResourceServer::class);
+        $this->response        = $this->prophesize(ResponseInterface::class);
+        $this->responseFactory = function () {
+            return $this->response->reveal();
+        };
     }
 
     public function testConstructor()
     {
-        $factory = function () {
-            return;
-        };
-
         $adapter = new OAuth2Adapter(
             $this->resourceServer->reveal(),
-            $factory
+            $this->responseFactory
         );
         $this->assertInstanceOf(OAuth2Adapter::class, $adapter);
         $this->assertInstanceOf(AuthenticationInterface::class, $adapter);
@@ -54,9 +62,7 @@ class OAuth2AdapterTest extends TestCase
 
         $adapter = new OAuth2Adapter(
             $this->resourceServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
 
         $this->assertNull($adapter->authenticate($request->reveal()));
@@ -73,9 +79,7 @@ class OAuth2AdapterTest extends TestCase
 
         $adapter = new OAuth2Adapter(
             $this->resourceServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
 
         $this->assertNull($adapter->authenticate($request->reveal()));
@@ -92,9 +96,7 @@ class OAuth2AdapterTest extends TestCase
 
         $adapter = new OAuth2Adapter(
             $this->resourceServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
 
         $user = $adapter->authenticate($request->reveal());
@@ -117,9 +119,7 @@ class OAuth2AdapterTest extends TestCase
 
         $adapter = new OAuth2Adapter(
             $this->resourceServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
 
         $this->assertSame(

--- a/test/OAuth2MiddlewareFactoryTest.php
+++ b/test/OAuth2MiddlewareFactoryTest.php
@@ -53,8 +53,8 @@ class OAuth2MiddlewareFactoryTest extends TestCase
             ->get(AuthorizationServer::class)
             ->willReturn($this->authServer->reveal());
         $this->container
-            ->has(ResponseInterface::class)
-            ->willReturn(false);
+            ->get(ResponseInterface::class)
+            ->willReturn(function () {});
 
         $factory = new OAuth2MiddlewareFactory();
         $middleware = $factory($this->container->reveal());

--- a/test/OAuth2MiddlewareFactoryTest.php
+++ b/test/OAuth2MiddlewareFactoryTest.php
@@ -54,7 +54,8 @@ class OAuth2MiddlewareFactoryTest extends TestCase
             ->willReturn($this->authServer->reveal());
         $this->container
             ->get(ResponseInterface::class)
-            ->willReturn(function () {});
+            ->willReturn(function () {
+            });
 
         $factory = new OAuth2MiddlewareFactory();
         $middleware = $factory($this->container->reveal());

--- a/test/OAuth2MiddlewareTest.php
+++ b/test/OAuth2MiddlewareTest.php
@@ -38,7 +38,9 @@ class OAuth2MiddlewareTest extends TestCase
     {
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
         $this->assertInstanceOf(OAuth2Middleware::class, $middleware);
         $this->assertInstanceOf(MiddlewareInterface::class, $middleware);
@@ -69,7 +71,9 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
         $response = $middleware->process(
             $this->serverRequest->reveal(),
@@ -92,7 +96,9 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
         $response = $middleware->process(
             $this->serverRequest->reveal(),
@@ -117,7 +123,9 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
 
         $this->serverRequest->getMethod()->willReturn('GET');
@@ -157,7 +165,9 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
 
         $this->serverRequest->getMethod()->willReturn('GET');
@@ -177,7 +187,9 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
 
         $response = $middleware->process(
@@ -206,7 +218,9 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
 
         $response = $middleware->process(
@@ -247,7 +261,9 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            $this->response->reveal()
+            function () {
+                return $this->response->reveal();
+            }
         );
 
         $response = $middleware->process(

--- a/test/OAuth2MiddlewareTest.php
+++ b/test/OAuth2MiddlewareTest.php
@@ -15,6 +15,7 @@ use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\RequestTypes\AuthorizationRequest;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
@@ -25,22 +26,41 @@ use Zend\Expressive\Authentication\OAuth2\OAuth2Middleware;
 
 class OAuth2MiddlewareTest extends TestCase
 {
+    /** @var AuthorizationRequest|ObjectProphecy */
+    private $authRequest;
+
+    /** @var AuthorizationServer|ObjectProphecy */
+    private $authServer;
+
+    /** @var RequestHandlerInterface|ObjectProphecy */
+    private $handler;
+
+    /** @var ResponseInterface|ObjectProphecy */
+    private $response;
+
+    /** @var callable */
+    private $responseFactory;
+
+    /** @var ServerRequestInterface|ObjectProphecy */
+    private $serverRequest;
+
     public function setUp()
     {
-        $this->authServer    = $this->prophesize(AuthorizationServer::class);
-        $this->response      = $this->prophesize(ResponseInterface::class);
-        $this->serverRequest = $this->prophesize(ServerRequestInterface::class);
-        $this->authRequest   = $this->prophesize(AuthorizationRequest::class);
-        $this->handler       = $this->prophesize(RequestHandlerInterface::class);
+        $this->authServer      = $this->prophesize(AuthorizationServer::class);
+        $this->response        = $this->prophesize(ResponseInterface::class);
+        $this->serverRequest   = $this->prophesize(ServerRequestInterface::class);
+        $this->authRequest     = $this->prophesize(AuthorizationRequest::class);
+        $this->handler         = $this->prophesize(RequestHandlerInterface::class);
+        $this->responseFactory = function () {
+            return $this->response->reveal();
+        };
     }
 
     public function testConstructor()
     {
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
         $this->assertInstanceOf(OAuth2Middleware::class, $middleware);
         $this->assertInstanceOf(MiddlewareInterface::class, $middleware);
@@ -71,9 +91,7 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
         $response = $middleware->process(
             $this->serverRequest->reveal(),
@@ -96,9 +114,7 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
         $response = $middleware->process(
             $this->serverRequest->reveal(),
@@ -123,9 +139,7 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
 
         $this->serverRequest->getMethod()->willReturn('GET');
@@ -165,9 +179,7 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
 
         $this->serverRequest->getMethod()->willReturn('GET');
@@ -187,9 +199,7 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
 
         $response = $middleware->process(
@@ -218,9 +228,7 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
 
         $response = $middleware->process(
@@ -261,9 +269,7 @@ class OAuth2MiddlewareTest extends TestCase
 
         $middleware = new OAuth2Middleware(
             $this->authServer->reveal(),
-            function () {
-                return $this->response->reveal();
-            }
+            $this->responseFactory
         );
 
         $response = $middleware->process(

--- a/test/Pdo/OAuth2PdoMiddlewareTest.php
+++ b/test/Pdo/OAuth2PdoMiddlewareTest.php
@@ -92,7 +92,12 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
     public function testConstructor()
     {
-        $authMiddleware = new OAuth2Middleware($this->authServer, $this->response);
+        $authMiddleware = new OAuth2Middleware(
+            $this->authServer,
+            function() {
+                return $this->response;
+            }
+        );
         $this->assertInstanceOf(OAuth2Middleware::class, $authMiddleware);
     }
 
@@ -123,7 +128,14 @@ class OAuth2PdoMiddlewareTest extends TestCase
             $params,
             [ 'Content-Type' => 'application/x-www-form-urlencoded' ]
         );
-        $authMiddleware = new OAuth2Middleware($this->authServer, $this->response);
+
+        $authMiddleware = new OAuth2Middleware(
+            $this->authServer,
+            function() {
+                return $this->response;
+            }
+        );
+
         $response = $authMiddleware->process($request, $this->handler->reveal());
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -166,7 +178,14 @@ class OAuth2PdoMiddlewareTest extends TestCase
             $params,
             [ 'Content-Type' => 'application/x-www-form-urlencoded' ]
         );
-        $authMiddleware = new OAuth2Middleware($this->authServer, $this->response);
+
+        $authMiddleware = new OAuth2Middleware(
+            $this->authServer,
+            function() {
+                return $this->response;
+            }
+        );
+
         $response = $authMiddleware->process($request, $this->handler->reveal());
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -214,7 +233,13 @@ class OAuth2PdoMiddlewareTest extends TestCase
             $params
         );
 
-        $authMiddleware = new OAuth2Middleware($this->authServer, $this->response);
+        $authMiddleware = new OAuth2Middleware(
+            $this->authServer,
+            function() {
+                return $this->response;
+            }
+        );
+
         $response = $authMiddleware->process($request, $this->handler->reveal());
 
         $this->assertEquals(302, $response->getStatusCode());
@@ -265,7 +290,14 @@ class OAuth2PdoMiddlewareTest extends TestCase
             $params,
             [ 'Content-Type' => 'application/x-www-form-urlencoded' ]
         );
-        $authMiddleware = new OAuth2Middleware($this->authServer, $this->response);
+
+        $authMiddleware = new OAuth2Middleware(
+            $this->authServer,
+            function() {
+                return $this->response;
+            }
+        );
+
         $response = $authMiddleware->process($request, $this->handler->reveal());
 
         $this->assertEquals(200, $response->getStatusCode());
@@ -307,7 +339,14 @@ class OAuth2PdoMiddlewareTest extends TestCase
             [],
             $params
         );
-        $authMiddleware = new OAuth2Middleware($this->authServer, $this->response);
+
+        $authMiddleware = new OAuth2Middleware(
+            $this->authServer,
+            function() {
+                return $this->response;
+            }
+        );
+
         $response = $authMiddleware->process($request, $this->handler->reveal());
 
         $this->assertEquals(302, $response->getStatusCode());
@@ -356,7 +395,13 @@ class OAuth2PdoMiddlewareTest extends TestCase
             [ 'Content-Type' => 'application/x-www-form-urlencoded' ]
         );
 
-        $authMiddleware = new OAuth2Middleware($this->authServer, $this->response);
+        $authMiddleware = new OAuth2Middleware(
+            $this->authServer,
+            function() {
+                return $this->response;
+            }
+        );
+
         $response = $authMiddleware->process($request, $this->handler->reveal());
 
         $this->assertEquals(200, $response->getStatusCode());

--- a/test/Pdo/OAuth2PdoMiddlewareTest.php
+++ b/test/Pdo/OAuth2PdoMiddlewareTest.php
@@ -94,7 +94,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
     {
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function() {
+            function () {
                 return $this->response;
             }
         );
@@ -131,7 +131,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function() {
+            function () {
                 return $this->response;
             }
         );
@@ -181,7 +181,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function() {
+            function () {
                 return $this->response;
             }
         );
@@ -235,7 +235,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function() {
+            function () {
                 return $this->response;
             }
         );
@@ -293,7 +293,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function() {
+            function () {
                 return $this->response;
             }
         );
@@ -342,7 +342,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function() {
+            function () {
                 return $this->response;
             }
         );
@@ -397,7 +397,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function() {
+            function () {
                 return $this->response;
             }
         );

--- a/test/Pdo/OAuth2PdoMiddlewareTest.php
+++ b/test/Pdo/OAuth2PdoMiddlewareTest.php
@@ -19,6 +19,7 @@ use League\OAuth2\Server\Grant\PasswordGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;
 use PDO;
 use PHPUnit\Framework\TestCase;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Server\RequestHandlerInterface;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\ServerRequest;
@@ -39,6 +40,39 @@ class OAuth2PdoMiddlewareTest extends TestCase
     const DB_DATA        = __DIR__ . '/TestAsset/test_data.sql';
     const PRIVATE_KEY    = __DIR__ .'/../TestAsset/private.key';
     const ENCRYPTION_KEY = 'T2x2+1OGrEzfS+01OUmwhOcJiGmE58UD1fllNn6CGcQ=';
+
+    /** @var AccessTokenRepository */
+    private $accessTokenRepository;
+
+    /** @var AuthCodeRepository */
+    private $authCodeRepository;
+
+    /** @var AuthServer */
+    private $authServer;
+
+    /** @var ClientRepository */
+    private $clientRepository;
+
+    /** @var RequestHandlerInterface|ObjectProphecy */
+    private $handler;
+
+    /** @var PdoService */
+    private $pdoService;
+
+    /** @var RefreshTokenRepository */
+    private $refreshTokenRepository;
+
+    /** @var Response */
+    private $response;
+
+    /** @var callable */
+    private $responseFactory;
+
+    /** @var ScopeRepository */
+    private $scopeRepository;
+
+    /** @var UserRepository */
+    private $userRepository;
 
     public static function setUpBeforeClass()
     {
@@ -88,15 +122,16 @@ class OAuth2PdoMiddlewareTest extends TestCase
         );
 
         $this->handler = $this->prophesize(RequestHandlerInterface::class);
+        $this->responseFactory = function () {
+            return $this->response;
+        };
     }
 
     public function testConstructor()
     {
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function () {
-                return $this->response;
-            }
+            $this->responseFactory
         );
         $this->assertInstanceOf(OAuth2Middleware::class, $authMiddleware);
     }
@@ -131,9 +166,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function () {
-                return $this->response;
-            }
+            $this->responseFactory
         );
 
         $response = $authMiddleware->process($request, $this->handler->reveal());
@@ -181,9 +214,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function () {
-                return $this->response;
-            }
+            $this->responseFactory
         );
 
         $response = $authMiddleware->process($request, $this->handler->reveal());
@@ -235,9 +266,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function () {
-                return $this->response;
-            }
+            $this->responseFactory
         );
 
         $response = $authMiddleware->process($request, $this->handler->reveal());
@@ -293,9 +322,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function () {
-                return $this->response;
-            }
+            $this->responseFactory
         );
 
         $response = $authMiddleware->process($request, $this->handler->reveal());
@@ -342,9 +369,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function () {
-                return $this->response;
-            }
+            $this->responseFactory
         );
 
         $response = $authMiddleware->process($request, $this->handler->reveal());
@@ -397,9 +422,7 @@ class OAuth2PdoMiddlewareTest extends TestCase
 
         $authMiddleware = new OAuth2Middleware(
             $this->authServer,
-            function () {
-                return $this->response;
-            }
+            $this->responseFactory
         );
 
         $response = $authMiddleware->process($request, $this->handler->reveal());


### PR DESCRIPTION
Using PR: https://github.com/zendframework/zend-expressive/pull/561 as a guide this PR removes the ResponsePrototypeTrait in favor of factoryFactories. 

Fixes issue: https://github.com/zendframework/zend-expressive-authentication-oauth2/issues/16
