### PR TITLE
Fixes unknown user will throw an exception

### DIFF
--- a/src/Repository/Pdo/UserRepository.php
+++ b/src/Repository/Pdo/UserRepository.php
@@ -33,7 +33,7 @@ class UserRepository extends AbstractRepository implements UserRepositoryInterfa
 
         $row = $sth->fetch();
 
-        if (!empty($row) && password_verify($password, $row['password'])) {
+        if (! empty($row) && password_verify($password, $row['password'])) {
             return new UserEntity($username);
         }
 

--- a/src/Repository/Pdo/UserRepository.php
+++ b/src/Repository/Pdo/UserRepository.php
@@ -30,11 +30,13 @@ class UserRepository extends AbstractRepository implements UserRepositoryInterfa
         if (false === $sth->execute()) {
             return;
         }
+
         $row = $sth->fetch();
 
-        if (password_verify($password, $row['password'])) {
+        if (!empty($row) && password_verify($password, $row['password'])) {
             return new UserEntity($username);
         }
+
         return;
     }
 }

--- a/test/Repository/Pdo/UserRepositoryTest.php
+++ b/test/Repository/Pdo/UserRepositoryTest.php
@@ -73,4 +73,29 @@ class UserRepositoryTest extends TestCase
             )
         );
     }
+
+    public function testGetUserEntityByCredentialsReturnsNullIfUserIsNotFound()
+    {
+        $statement = $this->prophesize(PDOStatement::class);
+        $statement->bindParam(':username', 'username')->shouldBeCalled();
+        $statement->execute()->will(function () use ($statement) {
+            $statement->fetch()->willReturn(null);
+            return null;
+        });
+
+        $this->pdo
+            ->prepare(Argument::containingString('SELECT password FROM oauth_users'))
+            ->will([$statement, 'reveal']);
+
+        $client = $this->prophesize(ClientEntityInterface::class);
+
+        $this->assertNull(
+            $this->repo ->getUserEntityByUserCredentials(
+                'username',
+                'password',
+                'auth',
+                $client->reveal()
+            )
+        );
+    }
 }


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:
When a user tries to use a username that doesn't exist in the database an exception is thrown instead of an invalid_credentials error.

[x]    Are you fixing a bug?

This checks to make sure that a user was indeed found in the db or returns if no user was found