### PR TITLE
Fixes exception thrown when client secret is missing

### DIFF
--- a/src/Repository/Pdo/ClientRepository.php
+++ b/src/Repository/Pdo/ClientRepository.php
@@ -32,9 +32,13 @@ class ClientRepository extends AbstractRepository implements ClientRepositoryInt
         if (empty($row) || ! $this->isGranted($row, $grantType)) {
             return;
         }
-        if ($mustValidateSecret && ! password_verify((string) $clientSecret, $row['secret'])) {
+
+        if ($mustValidateSecret
+            && (empty($row['secret']) || ! password_verify((string) $clientSecret, $row['secret']))
+        ) {
             return;
         }
+
         return new ClientEntity($clientIdentifier, $row['name'], $row['redirect']);
     }
 

--- a/test/Repository/Pdo/ClientRepositoryTest.php
+++ b/test/Repository/Pdo/ClientRepositoryTest.php
@@ -135,4 +135,32 @@ class ClientRepositoryTest extends TestCase
             )
         );
     }
+
+    public function testGetClientReturnsNullForEmptyClientSecret()
+    {
+        $statement = $this->prophesize(PDOStatement::class);
+        $statement->bindParam(':clientIdentifier', 'client_id')->shouldBeCalled();
+        $statement->execute()->will(function () use ($statement) {
+            $statement->fetch()->willReturn([
+                'password_client' => true,
+                'secret' => null,
+            ]);
+            return null;
+        });
+
+        $this->pdo
+            ->prepare(Argument::containingString('SELECT * FROM oauth_clients'))
+            ->will([$statement, 'reveal']);
+
+        $client = $this->prophesize(ClientEntityInterface::class);
+
+        $this->assertNull(
+            $this->repo ->getClientEntity(
+                'client_id',
+                'password_client',
+                'password',
+                true
+            )
+        );
+    }
 }


### PR DESCRIPTION
When a client id is used that has no client_secret in the database an exception is thrown instead of an invalid_client error.

[x] Are you fixing a bug?

This checks to make sure that a client_secret is returned from the db or returns if it was not found