### PR TITLE
Add auth interface to the config provider

### DIFF
--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -18,6 +18,7 @@ use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
 use League\OAuth2\Server\Repositories\ScopeRepositoryInterface;
 use League\OAuth2\Server\Repositories\UserRepositoryInterface;
 use League\OAuth2\Server\ResourceServer;
+use Zend\Expressive\Authentication\AuthenticationInterface;
 use Zend\Expressive\Authentication\OAuth2\Repository\Pdo;
 
 class ConfigProvider
@@ -47,7 +48,8 @@ class ConfigProvider
                 ClientRepositoryInterface::class => Pdo\ClientRepository::class,
                 RefreshTokenRepositoryInterface::class => Pdo\RefreshTokenRepository::class,
                 ScopeRepositoryInterface::class => Pdo\ScopeRepository::class,
-                UserRepositoryInterface::class => Pdo\UserRepository::class
+                UserRepositoryInterface::class => Pdo\UserRepository::class,
+                AuthenticationInterface::class => OAuth2Adapter::class
             ],
             'factories' => [
                 OAuth2Middleware::class => OAuth2MiddlewareFactory::class,


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [ ] Are you fixing a bug?
- [x] Are you creating a new feature?

Adds the AuthenticationInterface to the config provider so OAuth works out of the box.  Can always be overwritten in project configs.
