### PR TITLE
Fix for #36, added the /oauth route in docs

### DIFF
--- a/docs/book/index.html
+++ b/docs/book/index.html
@@ -2,7 +2,7 @@
   <div class="jumbotron">
     <h1>zendframework/zend-expressive-authentication-oauth2</h1>
 
-    <p>OAuth2 (server) authentication middleware for PSR-7 applications.</p>
+    <p>OAuth2 (server) for Expressive and PSR-7 applications.</p>
 
     <pre><code class="language-bash">$ composer require zendframework/zend-expressive-authentication-oauth2</code></pre>
   </div>

--- a/docs/book/intro.md
+++ b/docs/book/intro.md
@@ -112,3 +112,23 @@ These commands will insert the following testing values:
 For security reason, the client `secret` and the user `password` are stored
 using the `bcrypt` algorithm provided by [password_hash](http://php.net/manual/en/function.password-hash.php)
 function of PHP.
+
+## Configure the OAuth2 route
+
+As last step, in order to use the OAuth2 server you need to configure a route
+to point to `Zend\Expressive\Authentication\OAuth2\OAuth2Middleware` with
+GET and POST HTTP verbs.
+
+For instance, you can add the following route to your Expressive application:
+
+```php
+$app->route(
+    '/oauth',
+    Zend\Expressive\Authentication\OAuth2\OAuth2Middleware::class,
+    ['GET', 'POST'],
+    'oauth'
+);
+```
+
+With this configuration, you can interact with the OAuth2 server using `/oauth`
+URL.

--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -2,7 +2,8 @@
 
 If you successfully configured the OAuth2 server as detailed in the
 [installation](intro.md) section, you can request an access token using the
-default `/oauth` route.
+OAuth2 server route defined [before](intro.md#configure-the-oauth2-route)
+(e.g. `/oauth`).
 
 You can require an access token using one of the following scenarios:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,6 @@ pages:
         - "Implicit": grant/implicit.md
         - "Refresh token": grant/refresh_token.md
 site_name: OAuth2 middleware
-site_description: 'OAuth2 server authentication middleware for Expressive and PSR-7 applications.'
+site_description: 'OAuth2 (server) for Expressive and PSR-7 applications.'
 repo_url: 'https://github.com/zendframework/zend-expressive-authentication-oauth2'
 copyright: 'Copyright (c) 2015-2018 <a href="http://www.zend.com/">Zend Technologies USA Inc.</a>'


### PR DESCRIPTION
This PR fixes #36 adding the `/oauth` route configuration in the documentation.