### PR TITLE
Changed column type to varchar

### DIFF
--- a/data/oauth2.sql
+++ b/data/oauth2.sql
@@ -1,7 +1,7 @@
 CREATE TABLE oauth_auth_codes (
     id VARCHAR(100),
-    user_id INTEGER,
-    client_id INTEGER,
+    user_id VARCHAR(40),
+    client_id VARCHAR(40),
     scopes TEXT NULL,
     revoked BOOLEAN,
     expires_at TIMESTAMP NULL,


### PR DESCRIPTION
To work with the Auth Grant Type the columns user_id and client_id have to be varchar in the oauth_auth_codes table. 
See http://oauth2.thephpleague.com/auth-code-repository-interface/