### PR TITLE
Revocation of access token was fixed

### DIFF
--- a/src/Repository/Pdo/AccessTokenRepository.php
+++ b/src/Repository/Pdo/AccessTokenRepository.php
@@ -94,7 +94,7 @@ class AccessTokenRepository extends AbstractRepository implements AccessTokenRep
         $sth = $this->pdo->prepare(
             'UPDATE oauth_access_tokens SET revoked=:revoked WHERE id = :tokenId'
         );
-        $sth->bindValue(':revoked', 0);
+        $sth->bindValue(':revoked', 1);
         $sth->bindParam(':tokenId', $tokenId);
 
         $sth->execute();

--- a/test/Repository/Pdo/AccessTokenRepositoryTest.php
+++ b/test/Repository/Pdo/AccessTokenRepositoryTest.php
@@ -25,6 +25,11 @@ use function time;
 
 class AccessTokenRepositoryTest extends TestCase
 {
+    /**
+     * @var AccessTokenRepository
+     */
+    private $repo;
+
     public function setUp()
     {
         $this->pdo = $this->prophesize(PdoService::class);
@@ -124,5 +129,19 @@ class AccessTokenRepositoryTest extends TestCase
             ->will([$statement, 'reveal']);
 
         $this->assertTrue($this->repo->isAccessTokenRevoked('token_id'));
+    }
+
+    public function testRevokeAccessToken()
+    {
+        $statement = $this->prophesize(PDOStatement::class);
+        $statement->bindParam(':tokenId', 'token_id')->shouldBeCalled();
+        $statement->bindValue(':revoked', 1)->shouldBeCalled();
+        $statement->execute()->willReturn(null)->shouldBeCalled();
+
+        $this->pdo
+            ->prepare(Argument::containingString('UPDATE oauth_access_tokens SET revoked=:revoked'))
+            ->will([$statement, 'reveal']);
+
+        $this->repo->revokeAccessToken('token_id');
     }
 }


### PR DESCRIPTION
I'm fixing the bug in the method revokeAccessToken(), in AccessTokenRepository.

Incorrect behavior: the revokeAccessToken() method doesn't change the revoked field to 1.

New expected behavior:   the revokeAccessToken() method changes the revoked field to 1.

Provide a narrative description of what you are trying to accomplish:

