### PR TITLE
Fixed issue with empty scope being passed throwing exception

### DIFF
--- a/src/Repository/Pdo/AbstractRepository.php
+++ b/src/Repository/Pdo/AbstractRepository.php
@@ -39,6 +39,10 @@ class AbstractRepository
      */
     protected function scopesToString(array $scopes) : string
     {
+        if (empty($scopes)) {
+            return '';
+        }
+
         return trim(array_reduce($scopes, function ($result, $item) {
             return $result . ' ' . $item->getIdentifier();
         }));


### PR DESCRIPTION
Provide a narrative description of what you are trying to accomplish:

- [X] Are you fixing a bug?
  - [X] Detail how the bug is invoked currently.
  - [X] Detail the original, incorrect behavior.
  - [X] Detail the new, expected behavior.
  - [X] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

When sending post request for authorisation with blank scope following error occurs:
```TypeError: trim() expects parameter 1 to be string, null given in file /vendor/zendframework/zend-expressive-authentication-oauth2/src/Repository/Pdo/AbstractRepository.php on line 44```

This pull request checks to see if the scope being passed is blank, returns an empty string and returns authorisation.
