### PR TITLE
An OAuth2 client is not a user

### DIFF
--- a/src/OAuth2Adapter.php
+++ b/src/OAuth2Adapter.php
@@ -29,6 +29,11 @@ class OAuth2Adapter implements AuthenticationInterface
      */
     protected $responseFactory;
 
+    /**
+     * @var callable
+     */
+    protected $userFactory;
+
     public function __construct(
         ResourceServer $resourceServer,
         callable $responseFactory,
@@ -56,9 +61,9 @@ class OAuth2Adapter implements AuthenticationInterface
             $result = $this->resourceServer->validateAuthenticatedRequest($request);
             $userId = $result->getAttribute('oauth_user_id', null);
             $clientId = $result->getAttribute('oauth_client_id', null);
-            if (isset($userId) || isset($clientId)) {
+            if (isset($userId)) {
                 return ($this->userFactory)(
-                    $userId ?? $clientId,
+                    $userId,
                     [],
                     [
                         'oauth_user_id' => $userId,

--- a/test/OAuth2AdapterTest.php
+++ b/test/OAuth2AdapterTest.php
@@ -14,6 +14,7 @@ use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\ResourceServer;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Zend\Expressive\Authentication\AuthenticationInterface;
@@ -31,6 +32,9 @@ class OAuth2AdapterTest extends TestCase
 
     /** @var callable */
     private $responseFactory;
+
+    /** @var callable */
+    private $userFactory;
 
     public function setUp()
     {
@@ -122,7 +126,7 @@ class OAuth2AdapterTest extends TestCase
         $this->assertSame([], $user->getRoles());
     }
 
-    public function testAuthenticateReturnsAClientIfTheResourceServerProducesAClientId()
+    public function testAuthenticateReturnNullIfTheResourceServerProducesAClientIdOnly()
     {
         $request = $this->prophesize(ServerRequestInterface::class);
         $request->getAttribute('oauth_user_id', null)->willReturn(null);
@@ -141,10 +145,7 @@ class OAuth2AdapterTest extends TestCase
         );
 
         $user = $adapter->authenticate($request->reveal());
-
-        $this->assertInstanceOf(UserInterface::class, $user);
-        $this->assertSame('some-identifier', $user->getIdentity());
-        $this->assertSame([], $user->getRoles());
+        $this->assertNull($user);
     }
 
     public function testUnauthorizedResponseProducesAResponseWithAWwwAuthenticateHeader()


### PR DESCRIPTION
Currently the `OAuth2Adapter` "hooks" into the `zend-expressive-authentication` middleware as an adapter to manage authentication with OAuth2 and allows all forms of OAuth2 authentication.

In OAuth2 there are two things that need to authenticate. First an application (OAuth2 client) and secondly a specific user but this user authentication can be omitted by some grant types like the `client credentials` grant as this is meant for server <-> server communication where no specific user resources are needed. 

The problem is that the `zend-expressive-authentication` expects to authenticate a user and not something else and returning the OAuth2 client identifier as user identifier for `zend-expressive-authentication` can be very problematic.

Because of that the OAuth2 client should never be treated as authenticated user.

This PR only makes sure that an authenticated user will be returned by `AuthenticationInterface` but not an authenticated OAuth2 client.

Instead (not part of this PR as feature request) there should be another `AuthenticationMiddleware` specialized for authenticating OAuth2 clients - without the need for a user.

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
