### PR TITLE
Hotfix - updated configuration to register ConfigProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,9 @@
     "extra": {
         "branch-alias": {
             "dev-master": "0.4.x-dev"
+        },
+        "zf": {
+            "config-provider": "Zend\\Expressive\\Authentication\\OAuth2\\ConfigProvider"
         }
     },
     "bin": [


### PR DESCRIPTION
Because of the missing configuration in composer.json package has not been automatically registered.

Reported on forum: https://discourse.zendframework.com/t/composer-install-zend-expressive-authentication-oauth2-does-not-inject-config-provider-to-config-php/1175