### PR TITLE
Implemented the check of fetched row, if isn't a array, throw exception

### DIFF
--- a/src/Repository/Pdo/AccessTokenRepository.php
+++ b/src/Repository/Pdo/AccessTokenRepository.php
@@ -12,6 +12,7 @@ namespace Zend\Expressive\Authentication\OAuth2\Repository\Pdo;
 
 use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
 use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Exception\UniqueTokenIdentifierConstraintViolationException;
 use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
 use Zend\Expressive\Authentication\OAuth2\Entity\AccessTokenEntity;
@@ -114,6 +115,9 @@ class AccessTokenRepository extends AbstractRepository implements AccessTokenRep
             return false;
         }
         $row = $sth->fetch();
+        if (!is_array($row)) {
+            throw OAuthServerException::invalidRefreshToken();
+        }
 
         return array_key_exists('revoked', $row) ? (bool) $row['revoked'] : false;
     }

--- a/src/Repository/Pdo/AccessTokenRepository.php
+++ b/src/Repository/Pdo/AccessTokenRepository.php
@@ -115,7 +115,7 @@ class AccessTokenRepository extends AbstractRepository implements AccessTokenRep
             return false;
         }
         $row = $sth->fetch();
-        if (!is_array($row)) {
+        if (! is_array($row)) {
             throw OAuthServerException::invalidRefreshToken();
         }
 


### PR DESCRIPTION
Bug fix of issue #70 

Before the changes, if a tokenId previously generated by oAuth and delete from oauth_access_tokens, was submited, it throw a code 500  error, because of the row manipulation, was sent to a array_key_exists, but the fetch result was "false"

Now there's a check, if the row fetched isn't a array, throw a exception code 401

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] Add a regression test that demonstrates the bug, and proves the fix.
  - [ ] Add a `CHANGELOG.md` entry for the fix.

- [ ] Are you creating a new feature?
  - [ ] Why is the new feature needed? What purpose does it serve?
  - [ ] How will users use the new feature?
  - [ ] Base your feature on the `develop` branch, and submit against that branch.
  - [ ] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.
  - [ ] Add documentation for the new feature.
  - [ ] Add a `CHANGELOG.md` entry for the new feature.

- [ ] Is this related to quality assurance?
  <!-- Detail why the changes are necessary -->

- [ ] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
